### PR TITLE
handle Termination 

### DIFF
--- a/src/main/java/bgu/spl/mics/Subscriber.java
+++ b/src/main/java/bgu/spl/mics/Subscriber.java
@@ -116,13 +116,14 @@ public abstract class Subscriber extends RunnableSubPub {
         initialize();
         while (!terminated) {
             try {
+                if (Thread.currentThread().isInterrupted()) Thread.currentThread().interrupt();
                 Message message = _m.awaitMessage(this);
                 _messageToCallback.get(message.getClass()).call(message);
             } catch (InterruptedException e) {
                 terminate();
             }
-
         }
+        _m.unregister(this);
     }
 
 }

--- a/src/main/java/bgu/spl/mics/application/messages/TerminationTick.java
+++ b/src/main/java/bgu/spl/mics/application/messages/TerminationTick.java
@@ -1,9 +1,0 @@
-package bgu.spl.mics.application.messages;
-
-import bgu.spl.mics.Broadcast;
-
-public class TerminationTick implements Broadcast {
-    public TerminationTick() {
-
-    }
-}

--- a/src/main/java/bgu/spl/mics/application/messages/TerminationTickBroadcast.java
+++ b/src/main/java/bgu/spl/mics/application/messages/TerminationTickBroadcast.java
@@ -1,0 +1,9 @@
+package bgu.spl.mics.application.messages;
+
+import bgu.spl.mics.Broadcast;
+
+public class TerminationTickBroadcast implements Broadcast {
+    public TerminationTickBroadcast() {
+
+    }
+}

--- a/src/main/java/bgu/spl/mics/application/subscribers/Intelligence.java
+++ b/src/main/java/bgu/spl/mics/application/subscribers/Intelligence.java
@@ -1,8 +1,8 @@
 package bgu.spl.mics.application.subscribers;
 
-import bgu.spl.mics.Publisher;
 import bgu.spl.mics.Subscriber;
 import bgu.spl.mics.application.messages.MissionReceivedEvent;
+import bgu.spl.mics.application.messages.TerminationTickBroadcast;
 import bgu.spl.mics.application.messages.TickBroadcast;
 import bgu.spl.mics.application.passiveObjects.MissionInfo;
 
@@ -37,6 +37,7 @@ public class Intelligence extends Subscriber {
             while (b.getCurrTime() == _missions.peek().getTimeIssued())
                 getSimplePublisher().sendEvent(new MissionReceivedEvent(_missions.poll()));
         });
+        subscribeBroadcast(TerminationTickBroadcast.class, (TerminationTickBroadcast b)->terminate());
         _signalInitialized.countDown();
     }
 

--- a/src/main/java/bgu/spl/mics/application/subscribers/M.java
+++ b/src/main/java/bgu/spl/mics/application/subscribers/M.java
@@ -33,6 +33,7 @@ public class M extends Subscriber {
     @Override
     protected void initialize() {
         subscribeBroadcast(TickBroadcast.class, (TickBroadcast b) -> _currTime = b.getCurrTime());
+        subscribeBroadcast(TerminationTickBroadcast.class, (TerminationTickBroadcast b)->terminate());
         subscribeEvent(MissionReceivedEvent.class, (MissionReceivedEvent e) -> {
             diary.incrementTotal();
             // get all mission details

--- a/src/main/java/bgu/spl/mics/application/subscribers/Moneypenny.java
+++ b/src/main/java/bgu/spl/mics/application/subscribers/Moneypenny.java
@@ -3,6 +3,7 @@ package bgu.spl.mics.application.subscribers;
 import bgu.spl.mics.Subscriber;
 import bgu.spl.mics.application.messages.AgentsAvailableEvent;
 import bgu.spl.mics.application.messages.AgentsAvailableObject;
+import bgu.spl.mics.application.messages.TerminationTickBroadcast;
 import bgu.spl.mics.application.messages.TickBroadcast;
 import bgu.spl.mics.application.passiveObjects.Squad;
 
@@ -32,6 +33,7 @@ public class Moneypenny extends Subscriber {
     @Override
     protected void initialize() {
         subscribeBroadcast(TickBroadcast.class, (TickBroadcast b) -> _currTime = b.getCurrTime());
+        subscribeBroadcast(TerminationTickBroadcast.class, (TerminationTickBroadcast b)->terminate());
         subscribeEvent(AgentsAvailableEvent.class, (AgentsAvailableEvent e) -> {
             AgentsAvailableObject result = e.getObj();
             List<String> agentsSerials = result.getAgentsSerials();

--- a/src/main/java/bgu/spl/mics/application/subscribers/Q.java
+++ b/src/main/java/bgu/spl/mics/application/subscribers/Q.java
@@ -4,6 +4,7 @@ import bgu.spl.mics.Future;
 import bgu.spl.mics.Subscriber;
 import bgu.spl.mics.application.messages.GadgetAvailableEvent;
 import bgu.spl.mics.application.messages.GadgetAvailableObject;
+import bgu.spl.mics.application.messages.TerminationTickBroadcast;
 import bgu.spl.mics.application.messages.TickBroadcast;
 import bgu.spl.mics.application.passiveObjects.Inventory;
 
@@ -30,6 +31,7 @@ public class Q extends Subscriber {
     @Override
     protected void initialize() {
         subscribeBroadcast(TickBroadcast.class, (TickBroadcast b) -> _currTime = b.getCurrTime());
+        subscribeBroadcast(TerminationTickBroadcast.class, (TerminationTickBroadcast b)->terminate());
         subscribeEvent(GadgetAvailableEvent.class, (GadgetAvailableEvent e) ->
         {
             GadgetAvailableObject result = e.getObj();


### PR DESCRIPTION
1. rename TerminationTick to TerminationTickBroadcast to adapt to convention

2. subscribe all subscribers to TerminationTickBroadcast
3. add unregister call in Subscriber run() add handle interrupt when not blocked

Signed-off-by: Idan Tomer <idan.tomer2@gmail.com>