### PR TITLE
fix Interrupt Handling

### DIFF
--- a/src/main/java/bgu/spl/mics/Future.java
+++ b/src/main/java/bgu/spl/mics/Future.java
@@ -38,7 +38,8 @@ public class Future<T> {
         while (!_done)
             try {
                 this.wait();
-            } catch (InterruptedException ignored) {
+            } catch (InterruptedException e) {
+                return null;
             }
         return _result;
     }
@@ -79,7 +80,8 @@ public class Future<T> {
         while (!_done)
             try {
                 this.wait(TimeUnit.MILLISECONDS.convert(timeout, unit));
-            } catch (InterruptedException ignored) {
+            } catch (InterruptedException e) {
+                return null;
             }
         return _result;
     }

--- a/src/main/java/bgu/spl/mics/application/MI6Runner.java
+++ b/src/main/java/bgu/spl/mics/application/MI6Runner.java
@@ -55,7 +55,7 @@ public class MI6Runner {
         while (!timeService.isToTerminate()) {
             try {
                 timeService.wait();
-            } catch (InterruptedException ignored) {
+            } catch (InterruptedException ignored) { //main thread will never be interrupted
             }
         }
         e.shutdown();

--- a/src/main/java/bgu/spl/mics/application/passiveObjects/Squad.java
+++ b/src/main/java/bgu/spl/mics/application/passiveObjects/Squad.java
@@ -88,7 +88,7 @@ public class Squad {
      * @pre none
      * @post (for serial : serials { getAgents ( [serial]).state == BLOCKED})
      */
-    public boolean getAgents(List<String> serials) {
+    public boolean getAgents(List<String> serials) throws InterruptedException {
         Agent agent;
         // First, make sure all agent exists in the squad, to avoid acquiring and releasing.
         for (String serial : serials) {
@@ -101,10 +101,7 @@ public class Squad {
             agent = _agents.get(serial);
             synchronized (agent) {
                 while (!agent.isAvailable()) {
-                    try {
-                        agent.wait();
-                    } catch (InterruptedException ignored) {
-                    }
+                    agent.wait();
                     agent.acquire();
                 }
             }

--- a/src/main/java/bgu/spl/mics/application/subscribers/M.java
+++ b/src/main/java/bgu/spl/mics/application/subscribers/M.java
@@ -120,9 +120,8 @@ public class M extends Subscriber {
         GadgetAvailableObject gadgetAvailableObject = new GadgetAvailableObject(info.getGadget());
         Future<GadgetAvailableObject> gadgetAvailableFuture;
         gadgetAvailableFuture = this.getSimplePublisher().sendEvent(new GadgetAvailableEvent(gadgetAvailableObject));
-        // check whether Q acquired the gadget, and allocate all relevant details. timeout is needed for the case where
-        // Q already terminated, and M is in the middle of processing a mission.
-        gadgetAvailableObject = gadgetAvailableFuture.get(200, TimeUnit.MILLISECONDS); //M and Q uses the same gadgetObject
+        // check whether Q acquired the gadget, and allocate all relevant details.
+        gadgetAvailableObject = gadgetAvailableFuture.get(); //M and Q uses the same gadgetObject
         return gadgetAvailableObject;
     }
 }

--- a/src/main/java/bgu/spl/mics/application/subscribers/Moneypenny.java
+++ b/src/main/java/bgu/spl/mics/application/subscribers/Moneypenny.java
@@ -37,8 +37,13 @@ public class Moneypenny extends Subscriber {
             List<String> agentsSerials = result.getAgentsSerials();
             java.util.Collections.sort(agentsSerials);
             result.setMoneypennySerial(_serial);
-            if (squad.getAgents(agentsSerials)) {
-                result.setAgentsNames(squad.getAgentsNames(agentsSerials));
+
+            try {
+                if (squad.getAgents(agentsSerials)) {
+                    result.setAgentsNames(squad.getAgentsNames(agentsSerials));
+                }
+            } catch (InterruptedException ex) {
+                complete(e, null);
             }
             complete(e, result);
             while (!result.isSendMission() || !result.isTerminateMission()) {

--- a/src/test/java/bgu/spl/mics/SquadTest.java
+++ b/src/test/java/bgu/spl/mics/SquadTest.java
@@ -38,7 +38,10 @@ public class SquadTest {
 
     @Test
     public void testGetSendAgents() {
-        squad.getAgents(agentsSerials);
+        try {
+            squad.getAgents(agentsSerials);
+        } catch (InterruptedException ignored) {
+        }
         for (Agent agent : agents) {
             assertFalse(agent.isAvailable(), "agent is still available after being acquired");
         }


### PR DESCRIPTION
1. getAgents now throws an exception when interrupted
2. in M - change get(timeout) to get()
3. Moneypenny now handles InterruptedException from getAgents and returns completes Future with null
4. MI6Runner - add a comment about why we're ignoring InterruptedException
5. Future - catch InterruptedException and return null

Signed-off-by: Idan Tomer <idan.tomer2@gmail.com>